### PR TITLE
Fix Constraint mit Interne Nutzungsdatum vs. Public Nutzungsdatum

### DIFF
--- a/src/LG_GeolAssets_V2.ili
+++ b/src/LG_GeolAssets_V2.ili
@@ -200,9 +200,10 @@ VERSION "2022-04-06"  =
       */
       SET CONSTRAINT WHERE NOT (InternalUse->IsAvailable):
          NOT (PublicUse->IsAvailable);
-      /** Wenn das Startdatum der Öffentichennutzung gesetzt ist, dann muss auch das Startdatum der Internennutzung gesetzt sein und das interne Startdatum muss kleiner oder gleich dem öffentlichen sein.
+      /** Wenn das Startdatum der Öffentichennutzung gesetzt ist, dann muss der Status der Internennutzung entweder auf TRUE (= nutzbar) stehen oder auch das Startdatum der Internennutzung gesetzt sein und das interne Startdatum muss kleiner oder gleich dem öffentlichen sein.
       */
       SET CONSTRAINT WHERE DEFINED (PublicUse->DateStartAvailability): 
+      (InternalUse->IsAvailable) OR 
       DEFINED(InternalUse->DateStartAvailability) AND 
       (InternalUse->DateStartAvailability <= PublicUse->DateStartAvailability);
       /** Wenn das öffentliche Startdatum gesetzt ist, dann darf der öffentliche Nutzungsstatus nicht auf TRUE (= nutzbar) stehen

--- a/src/LG_GeolAssets_V2.ili
+++ b/src/LG_GeolAssets_V2.ili
@@ -200,7 +200,7 @@ VERSION "2022-04-06"  =
       */
       SET CONSTRAINT WHERE NOT (InternalUse->IsAvailable):
          NOT (PublicUse->IsAvailable);
-      /** Wenn das Startdatum der Öffentichennutzung gesetzt ist, dann muss der Status der Internennutzung entweder auf TRUE (= nutzbar) stehen oder auch das Startdatum der Internennutzung gesetzt sein und das interne Startdatum muss kleiner oder gleich dem öffentlichen sein.
+      /** Wenn das Startdatum der öffentlichen Nutzung gesetzt ist, dann muss entweder der Status der internen Nutzung auf TRUE (= nutzbar) stehen oder (OR) das Startdatum der internen Nutzung gesetzt sein (dann muss der Status der internen Nutzung ja auf FALSE stehen) und (AND) das Startdatum der internen Nutzung muss kleiner oder gleich dem der öffentlichen Nutzung sein.
       */
       SET CONSTRAINT WHERE DEFINED (PublicUse->DateStartAvailability): 
       (InternalUse->IsAvailable) OR 


### PR DESCRIPTION
Wenn der Internenutzungstatus TRUE ist, dann muss nicht geprüft werden ob das Datum des Publicuse später ist als das des Internaluse. fixes #78